### PR TITLE
Fix missing imports and non-existent classes

### DIFF
--- a/Service/Bcs/BcsServiceProvider.php
+++ b/Service/Bcs/BcsServiceProvider.php
@@ -27,7 +27,6 @@ namespace Dhl\Shipping\Service\Bcs;
 
 use Dhl\Shipping\Api\Data\ServiceSettingsInterface;
 use Dhl\Shipping\Api\Data\ServiceInterface;
-use Dhl\Shipping\Api\ServicePoolInterface;
 use Dhl\Shipping\Api\ServiceProviderInterface;
 use Dhl\Shipping\Service\ServiceInputBuilder;
 
@@ -44,17 +43,17 @@ class BcsServiceProvider implements ServiceProviderInterface
 {
 
     private static $settingsClassMap = [
-        ServicePoolInterface::SERVICE_COD_CODE       => Cod::class,
-        ServicePoolInterface::SERVICE_INSURANCE_CODE => Insurance::class,
-        BulkyGoods::CODE                             => BulkyGoods::class,
-        ParcelAnnouncement::CODE                     => ParcelAnnouncement::class,
-        PreferredDay::CODE                           => PreferredDay::class,
-        PreferredLocation::CODE                      => PreferredLocation::class,
-        PreferredNeighbour::CODE                     => PreferredNeighbour::class,
-        PreferredTime::CODE                          => PreferredTime::class,
-        PrintOnlyIfCodeable::CODE                    => PrintOnlyIfCodeable::class,
-        ReturnShipment::CODE                         => ReturnShipment::class,
-        VisualCheckOfAge::CODE                       => VisualCheckOfAge::class,
+        Cod::CODE                 => Cod::class,
+        Insurance::CODE           => Insurance::class,
+        BulkyGoods::CODE          => BulkyGoods::class,
+        ParcelAnnouncement::CODE  => ParcelAnnouncement::class,
+        PreferredDay::CODE        => PreferredDay::class,
+        PreferredLocation::CODE   => PreferredLocation::class,
+        PreferredNeighbour::CODE  => PreferredNeighbour::class,
+        PreferredTime::CODE       => PreferredTime::class,
+        PrintOnlyIfCodeable::CODE => PrintOnlyIfCodeable::class,
+        ReturnShipment::CODE      => ReturnShipment::class,
+        VisualCheckOfAge::CODE    => VisualCheckOfAge::class,
     ];
 
     /**

--- a/Service/Gla/GlaServiceProvider.php
+++ b/Service/Gla/GlaServiceProvider.php
@@ -42,8 +42,8 @@ use Dhl\Shipping\Service\ServiceInputBuilder;
 class GlaServiceProvider implements ServiceProviderInterface
 {
     private static $settingsClassMap = [
-        ServicePoolInterface::SERVICE_COD_CODE       => Cod::class,
-        ServicePoolInterface::SERVICE_INSURANCE_CODE => Insurance::class,
+        Cod::CODE       => Cod::class,
+        Insurance::CODE => Insurance::class,
     ];
 
     /**

--- a/Service/ServiceFactory.php
+++ b/Service/ServiceFactory.php
@@ -24,6 +24,18 @@
  */
 namespace Dhl\Shipping\Service;
 
+use Dhl\Shipping\Service\Bcs\BulkyGoods;
+use Dhl\Shipping\Service\Bcs\Cod;
+use Dhl\Shipping\Service\Bcs\Insurance;
+use Dhl\Shipping\Service\Bcs\ParcelAnnouncement;
+use Dhl\Shipping\Service\Bcs\PreferredDay;
+use Dhl\Shipping\Service\Bcs\PreferredLocation;
+use Dhl\Shipping\Service\Bcs\PreferredNeighbour;
+use Dhl\Shipping\Service\Bcs\PreferredTime;
+use Dhl\Shipping\Service\Bcs\PrintOnlyIfCodeable;
+use Dhl\Shipping\Service\Bcs\ReturnShipment;
+use Dhl\Shipping\Service\Bcs\VisualCheckOfAge;
+
 /**
  * ServiceFactory
  *
@@ -41,7 +53,7 @@ class ServiceFactory
      * @param string $code
      * @param string $value
      *
-     * @return ServiceInterface|null
+     * @return AbstractService|null
      */
     public static function get($code, $value)
     {


### PR DESCRIPTION
This PR fixes some missing `use` statements and the usage of some non-existent classes.
Having those wrong pieces of code is a problem because Magento, before running integration tests, tries to do some reflection magic which fails in `\Dhl\Shipping\Service\Bcs\BcsServiceProvider` (see `\Magento\TestFramework\Workaround\Cleanup\StaticProperties::backupStaticVariables`)